### PR TITLE
Refactor file header to use a struct representation

### DIFF
--- a/persistence_test.go
+++ b/persistence_test.go
@@ -3,7 +3,6 @@ package radixdb
 import (
 	"encoding/binary"
 	"fmt"
-	"hash/crc32"
 	"testing"
 	"time"
 )
@@ -58,10 +57,7 @@ func TestFileHeaderSerialize(t *testing.T) {
 	}
 
 	got := binary.LittleEndian.Uint32(buf[fileHeaderSize()-sizeOfUint32:])
-
-	h := crc32.NewIEEE()
-	h.Write(buf[:fileHeaderSize()-sizeOfUint32])
-	want := h.Sum32()
+	want, _ := calculateChecksum(buf[:fileHeaderSize()-sizeOfUint32])
 
 	if got != want {
 		t.Fatalf("invalid header checksum, got:%d, want:%d", got, want)

--- a/radixdb.go
+++ b/radixdb.go
@@ -47,10 +47,12 @@ type RadixDB struct {
 // New initializes and returns a new instance of RadixDB.
 func New() *RadixDB {
 	ret := &RadixDB{
+		header: fileHeader{
+			magic:   magicByte,
+			version: fileFormatVersion,
+		},
 		blobs: map[blobID]*blobStoreEntry{},
 	}
-
-	ret.initFileHeader()
 
 	return ret
 }
@@ -510,10 +512,4 @@ func (rdb *RadixDB) traverse(cb func(*node) error) error {
 	}
 
 	return nil
-}
-
-// initFileHeader initializes the file header for RadixDB, setting up initial
-// values and reserving space for future population.
-func (rdb *RadixDB) initFileHeader() {
-	rdb.header = newFileHeader()
 }


### PR DESCRIPTION
I initially implemented the `fileHeader` mechanism as a `type fileHeader []byte`, performing binary operations directly on the byte slice. While this approach was useful during the initial stage, it proved to be too low-level without providing any significant benefits. Therefore, I have refactored `fileHeader` into a proper Go struct to improve clarity and maintainability. It goes without saying that the updated code continues to produce platform-agnostic binary data for the header.